### PR TITLE
Fixed bourbon deprecations

### DIFF
--- a/app/assets/stylesheets/active_admin/sortable.sass
+++ b/app/assets/stylesheets/active_admin/sortable.sass
@@ -29,7 +29,7 @@ body.active_admin
           height: 3em
           background: lighten($cOddRowBackground, 10%)
           border: 1px dashed $cRowSelected
-          +box-sizing(border-box)
+          box-sizing: border-box
 
           &.cantdoit
             border: 1px dashed $cRowError


### PR DESCRIPTION
Fixed `bourbon` deprecations:
- border-box deprecation. 
- sass .css prefix deprecation.