### PR TITLE
Fix Rails 5 DEPRECATION WARNING

### DIFF
--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -13,7 +13,7 @@ module ActiveAdmin
         @collection = @collection.sort_by do |a|
           a.send(options[:sorting_attribute]) || 1
         end
-        @resource_name = active_admin_config.resource_name.to_s.underscore.parameterize('_')
+        @resource_name = active_admin_config.resource_name.to_s.underscore.parameterize(separator: '_')
 
         # Call the block passed in. This will set the
         # title and body methods
@@ -165,4 +165,3 @@ module ActiveAdmin
     end
   end
 end
-


### PR DESCRIPTION
Fix DEPRECATION WARNING: Passing the separator argument as a positional parameter
