### PR TITLE
Add support for Rails 5.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/dummy/public/assets
 spec/dummy/.sass-cache
-
+vendor/bundle
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 language: ruby
 
 rvm:
-  - 2.1
   - 2.2
-  - 1.9.3
+  - 2.3
+  - 2.4
 
 env:
   - RAILS_VERSION=3.2
-  - RAILS_VERSION=4.0
-  - RAILS_VERSION=4.1
+  - RAILS_VERSION=4.2
+  - RAILS_VERSION=5.0
+  - RAILS_VERSION=5.1
 
 matrix:
   exclude:
     - rvm: 2.2
       env: RAILS_VERSION=3.2
+    - rvm: 2.4
+      env: RAILS_VERSION=3.2
+
+    - rvm: 2.2
+      env: RAILS_VERSION=5.0
+    - rvm: 2.2
+      env: RAILS_VERSION=5.1
 
 sudo: false

--- a/active_admin-sortable_tree.gemspec
+++ b/active_admin-sortable_tree.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails',           '>= 3.2'
   s.add_dependency 'activeadmin',     '>= 0.6'
-  s.add_dependency 'jquery-ui-rails', '~> 5.0'
+  s.add_dependency 'jquery-ui-rails', '>= 5.0'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'rspec-rails'

--- a/app/assets/javascripts/active_admin/sortable_core.js.coffee
+++ b/app/assets/javascripts/active_admin/sortable_core.js.coffee
@@ -1,0 +1,71 @@
+#= require jquery.mjs.nestedSortable
+
+window.ActiveAdminSortableEvent = do ->
+  eventToListeners = {}
+
+  return {
+    add: (event, callback) ->
+      if not eventToListeners.hasOwnProperty(event)
+        eventToListeners[event] = []
+      eventToListeners[event].push(callback)
+
+    trigger: (event, args) ->
+      if eventToListeners.hasOwnProperty(event)
+        for callback in eventToListeners[event]
+          try
+            callback.call(null, args)
+          catch e
+            console.error(e) if console and console.error
+  }
+
+$ ->
+  $('.disclose').bind 'click', (event) ->
+    $(this).closest('li').toggleClass('mjs-nestedSortable-collapsed').toggleClass('mjs-nestedSortable-expanded')
+
+  $(".index_as_sortable [data-sortable-type]").each ->
+    $this = $(@)
+
+    if $this.data('sortable-type') == "tree"
+      max_levels = $this.data('max-levels')
+      tab_hack = 20 # nestedSortable default
+    else
+      max_levels = 1
+      tab_hack = 99999
+
+    $this.nestedSortable
+      forcePlaceholderSize: true
+      forceHelperSizeType: true
+      errorClass: 'cantdoit'
+      disableNesting: 'cantdoit'
+      handle: '> .item'
+      listType: 'ol'
+      items: 'li'
+      opacity: .6
+      placeholder: 'placeholder'
+      revert: 250
+      maxLevels: max_levels,
+      tabSize: tab_hack
+      protectRoot: $this.data('protect-root')
+      # prevent drag flickers
+      tolerance: 'pointer'
+      toleranceElement: '> div'
+      isTree: true
+      startCollapsed: $this.data("start-collapsed")
+      update: ->
+        $this.nestedSortable("disable")
+        $.ajax
+          url: $this.data("sortable-url")
+          type: "post"
+          data: $this.nestedSortable("serialize")
+        .always ->
+          $this.find('.item').each (index) ->
+            if index % 2
+              $(this).removeClass('odd').addClass('even')
+            else
+              $(this).removeClass('even').addClass('odd')
+          $this.nestedSortable("enable")
+          ActiveAdminSortableEvent.trigger('ajaxAlways')
+        .done ->
+          ActiveAdminSortableEvent.trigger('ajaxDone')
+        .fail ->
+          ActiveAdminSortableEvent.trigger('ajaxFail')

--- a/app/assets/javascripts/active_admin/sortable_ui5.js.coffee
+++ b/app/assets/javascripts/active_admin/sortable_ui5.js.coffee
@@ -1,2 +1,2 @@
-#= require jquery-ui/widgets/sortable
+#= require jquery-ui/sortable
 #= require active_admin/sortable_core

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -5,3 +5,6 @@ gem "ancestry"
 gem "sass-rails"
 gem "sqlite3"
 gem "activeadmin", "~> 0.6.6"
+gem 'test-unit', '~> 3.0'
+
+# vim: ft=ruby

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,0 +1,12 @@
+gem 'jquery-rails'
+gem 'jquery-ui-rails'
+gem 'ancestry'
+gem 'sqlite3'
+
+# ActiveAdmin 1.0.0pre
+gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'devise'
+gem 'rails', '~> 4.2.0'
+gem 'sass-rails'
+
+# vim: ft=ruby

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -6,5 +6,7 @@ gem 'sqlite3'
 # ActiveAdmin 1.0.0pre
 gem 'activeadmin', github: 'gregbell/active_admin'
 gem 'devise'
-gem 'rails', '~> 4.0'
-gem 'sass-rails', '~> 4.0.2'
+gem 'rails', '~> 5.0.0'
+gem 'sass-rails'
+
+# vim: ft=ruby

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -6,5 +6,7 @@ gem 'sqlite3'
 # ActiveAdmin 1.0.0pre
 gem 'activeadmin', github: 'gregbell/active_admin'
 gem 'devise'
-gem 'rails', '~> 4.1'
-gem 'sass-rails', '~> 4.0.2'
+gem 'rails', '~> 5.1.0'
+gem 'sass-rails'
+
+# vim: ft=ruby

--- a/lib/active_admin/sortable_tree.rb
+++ b/lib/active_admin/sortable_tree.rb
@@ -1,3 +1,4 @@
+require 'active_admin/sortable_tree/compatibility'
 require 'active_admin/sortable_tree/engine'
 require 'active_admin/sortable_tree/controller_actions'
 require 'active_admin/views/index_as_sortable'

--- a/lib/active_admin/sortable_tree/compatibility.rb
+++ b/lib/active_admin/sortable_tree/compatibility.rb
@@ -1,0 +1,11 @@
+module ActiveAdmin::SortableTree
+  class Compatibility
+    def self.normalized_resource_name(resource_name)
+      if Rails::VERSION::MAJOR >= 5
+        resource_name.to_s.underscore.parameterize(separator: "_".freeze)
+      else
+        resource_name.to_s.underscore.parameterize("_".freeze)
+      end
+    end
+  end
+end

--- a/lib/active_admin/sortable_tree/controller_actions.rb
+++ b/lib/active_admin/sortable_tree/controller_actions.rb
@@ -24,10 +24,12 @@ module ActiveAdmin::SortableTree
       collection_action :sort, :method => :post do
         resource_name = active_admin_config.resource_name.to_s.underscore.parameterize('_')
 
-        records = params[resource_name].inject({}) do |res, (resource, parent_resource)|
-          res[resource_class.find(resource)] = resource_class.find(parent_resource) rescue nil
-          res
+        records = []
+        params[resource_name].each_pair do |resource, parent_resource|
+          parent_resource = resource_class.find(parent_resource) rescue nil
+          records << [resource_class.find(resource), parent_resource]
         end
+
         errors = []
         ActiveRecord::Base.transaction do
           records.each_with_index do |(record, parent_record), position|

--- a/lib/active_admin/sortable_tree/controller_actions.rb
+++ b/lib/active_admin/sortable_tree/controller_actions.rb
@@ -22,7 +22,7 @@ module ActiveAdmin::SortableTree
       config.paginate = false
 
       collection_action :sort, :method => :post do
-        resource_name = active_admin_config.resource_name.to_s.underscore.parameterize('_')
+        resource_name = ActiveAdmin::SortableTree::Compatibility.normalized_resource_name(active_admin_config.resource_name)
 
         records = []
         params[resource_name].each_pair do |resource, parent_resource|

--- a/lib/active_admin/sortable_tree/engine.rb
+++ b/lib/active_admin/sortable_tree/engine.rb
@@ -1,18 +1,32 @@
 require 'activeadmin'
+require "rubygems"
 
 module ActiveAdmin
   module SortableTree
     class Engine < ::Rails::Engine
       engine_name 'active_admin-sortable_tree'
 
+
+      def jquery_ui_six?
+        Gem::Version.new(Jquery::Ui::Rails::VERSION) >= Gem::Version.new("6.0.0")
+      end
+
+      def sortable_js
+        if jquery_ui_six?
+          "active_admin/sortable.js"
+        else
+          "active_admin/sortable_ui5.js"
+        end
+      end
+
       initializer "Rails precompile hook", group: :all do |app|
         app.config.assets.precompile += [ "active_admin/sortable.css",
-                                          "active_admin/sortable.js" ]
+                                          sortable_js ]
       end
 
       initializer "add assets" do
         ActiveAdmin.application.register_stylesheet "active_admin/sortable.css"
-        ActiveAdmin.application.register_javascript "active_admin/sortable.js"
+        ActiveAdmin.application.register_javascript sortable_js
       end
     end
   end

--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -13,7 +13,8 @@ module ActiveAdmin
         @collection = @collection.sort_by do |a|
           a.send(options[:sorting_attribute]) || 1
         end
-        @resource_name = active_admin_config.resource_name.to_s.underscore.parameterize('_')
+
+        @resource_name = ActiveAdmin::SortableTree::Compatibility.normalized_resource_name(active_admin_config.resource_name)
 
         # Call the block passed in. This will set the
         # title and body methods

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -5,7 +5,7 @@ module WaitForAjax
 
     yield
 
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?(count)
     end
 


### PR DESCRIPTION
- Provides support for Rails 5.0 and 5.1.
- Allow `jquery-ui-rails` to be `>= 5.0` (previously `~> 5.0`)