### PR TITLE
Move assets register to the user files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ end
 
 Currently supports only IndexAsBlock, more to come!
 
+**Assets**:
+```ruby
+# app/assets/javascripts/active_admin.js
+//= require active_admin/sortable
+```
+
+```ruby
+# app/assets/stylesheets/active_admin.scss
+@import "active_admin/sortable";
+```
+
 **Admin**:
 ```ruby
 # app/admin/page.rb

--- a/lib/active_admin/sortable_tree/engine.rb
+++ b/lib/active_admin/sortable_tree/engine.rb
@@ -5,25 +5,6 @@ module ActiveAdmin
   module SortableTree
     class Engine < ::Rails::Engine
       engine_name 'active_admin-sortable_tree'
-
-
-      def jquery_ui_six?
-        return false unless defined?(Jquery::Ui)
-        Gem::Version.new(Jquery::Ui::Rails::VERSION) >= Gem::Version.new("6.0.0")
-      end
-
-      def sortable_js
-        if jquery_ui_six?
-          "active_admin/sortable.js"
-        else
-          "active_admin/sortable_ui5.js"
-        end
-      end
-
-      initializer "Rails precompile hook", group: :all do |app|
-        app.config.assets.precompile += [ "active_admin/sortable.css",
-                                          sortable_js ]
-      end
     end
   end
 end

--- a/lib/active_admin/sortable_tree/engine.rb
+++ b/lib/active_admin/sortable_tree/engine.rb
@@ -8,6 +8,7 @@ module ActiveAdmin
 
 
       def jquery_ui_six?
+        return false unless defined?(Jquery::Ui)
         Gem::Version.new(Jquery::Ui::Rails::VERSION) >= Gem::Version.new("6.0.0")
       end
 
@@ -22,11 +23,6 @@ module ActiveAdmin
       initializer "Rails precompile hook", group: :all do |app|
         app.config.assets.precompile += [ "active_admin/sortable.css",
                                           sortable_js ]
-      end
-
-      initializer "add assets" do
-        ActiveAdmin.application.register_stylesheet "active_admin/sortable.css"
-        ActiveAdmin.application.register_javascript sortable_js
       end
     end
   end

--- a/spec/dummy/app/assets/javascripts/active_admin.js
+++ b/spec/dummy/app/assets/javascripts/active_admin.js
@@ -1,2 +1,3 @@
 //= require active_admin/base
 //= require jquery.simulate
+//= require active_admin/sortable

--- a/spec/dummy/app/assets/stylesheets/active_admin.css.scss
+++ b/spec/dummy/app/assets/stylesheets/active_admin.css.scss
@@ -10,6 +10,7 @@
 // Active Admin's got SASS!
 @import "active_admin/mixins";
 @import "active_admin/base";
+@import "active_admin/sortable";
 
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,0 +1,14 @@
+def jquery_ui_six?
+  return false unless defined?(Jquery::Ui)
+  Gem::Version.new(Jquery::Ui::Rails::VERSION) >= Gem::Version.new("6.0.0")
+end
+
+def sortable_js
+  if jquery_ui_six?
+    "active_admin/sortable.js"
+  else
+    "active_admin/sortable_ui5.js"
+  end
+end
+
+Dummy::Application.config.assets.precompile += [ "active_admin/sortable.css", sortable_js ]


### PR DESCRIPTION
New AA (1.1+) will deprecate assets registering.