### PR TITLE
Update dependencies ActiveAdmin < 1.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2017-10-17
+
+### Changed
+
+- Update dependencies to only support ActiveAdmin `< 1.1.0` because `v1.1.0`
+  [dropped its dependency on `jquery-ui-rails`](https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md).
+
 ## [1.0.0] - 2017-06-01
 
 ### Added
@@ -51,3 +58,4 @@ All notable changes to this project will be documented in this file.
 [0.2.1]: https://github.com/zorab47/active_admin-sortable_tree/compare/v0.2.0...v0.2.1
 [0.3.0]: https://github.com/zorab47/active_admin-sortable_tree/compare/v0.2.1...v0.3.0
 [1.0.0]: https://github.com/zorab47/active_admin-sortable_tree/compare/v0.3.0...v1.0.0
+[1.1.0]: https://github.com/zorab47/active_admin-sortable_tree/compare/v1.0.0...v1.1.0

--- a/active_admin-sortable_tree.gemspec
+++ b/active_admin-sortable_tree.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files app lib vendor`.split($\) + ["Changelog.md", "README.md", "MIT-LICENSE"]
 
   s.add_dependency 'rails',           '>= 3.2'
-  s.add_dependency 'activeadmin',     '>= 0.6'
+  s.add_dependency 'activeadmin',     '>= 0.6', "< 1.1.0"
   s.add_dependency 'jquery-ui-rails', '>= 5.0'
 
   s.add_development_dependency 'capybara'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -3,8 +3,7 @@ gem 'jquery-ui-rails'
 gem 'ancestry'
 gem 'sqlite3'
 
-# ActiveAdmin 1.0.0pre
-gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'activeadmin'
 gem 'devise'
 gem 'rails', '~> 4.2.0'
 gem 'sass-rails'

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -3,8 +3,7 @@ gem 'jquery-ui-rails'
 gem 'ancestry'
 gem 'sqlite3'
 
-# ActiveAdmin 1.0.0pre
-gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'activeadmin'
 gem 'devise'
 gem 'rails', '~> 5.0.0'
 gem 'sass-rails'

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -3,8 +3,7 @@ gem 'jquery-ui-rails'
 gem 'ancestry'
 gem 'sqlite3'
 
-# ActiveAdmin 1.0.0pre
-gem 'activeadmin', github: 'gregbell/active_admin'
+gem 'activeadmin'
 gem 'devise'
 gem 'rails', '~> 5.1.0'
 gem 'sass-rails'

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,3 +1,4 @@
+gem 'puma'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'ancestry'


### PR DESCRIPTION
Update dependencies to only support ActiveAdmin `< 1.1.0` because `v1.1.0` [dropped its dependency on `jquery-ui-rails`](https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md).