### PR TITLE
Specify minimal required Ruby version

### DIFF
--- a/active_admin-sortable_tree.gemspec
+++ b/active_admin-sortable_tree.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 
   s.files       = `git ls-files app lib vendor`.split($\) + ["Changelog.md", "README.md", "MIT-LICENSE"]
 
+  s.required_ruby_version = '>= 2.2'
+
   s.add_dependency 'activeadmin', '>= 1.1'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'jquery-rails'


### PR DESCRIPTION
You should specify what is the minimal supported Ruby version.

This PR sets it to >= 2.2 based on your travis.yml.

If that's the case, you should consider changing your `require` to `require_relative`